### PR TITLE
Guardar firebaseUID como identificador de usuario en comentario

### DIFF
--- a/models/foro/comentario.model.js
+++ b/models/foro/comentario.model.js
@@ -3,7 +3,7 @@ const Schema = mongoose.Schema;
 const moment = require('moment-timezone');
 
 const comentarioSchema = new Schema({
-    username: {
+    firebaseUID: {
         type: String,
         required: true
     },

--- a/models/foro/comentario.model.js
+++ b/models/foro/comentario.model.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const moment = require('moment-timezone');
+const { getFechaConsulta } = require('../actividades/consultarActividades.model');
 
 const comentarioSchema = new Schema({
     firebaseUID: {
@@ -19,7 +19,7 @@ const comentarioSchema = new Schema({
     },
     fecha: {
         type: Date,
-        default: () => moment.tz('America/Mexico_City').toDate(),
+        default: getFechaConsulta,
         immutable: true
     },
     modificacion: {

--- a/models/foro/foro.model.js
+++ b/models/foro/foro.model.js
@@ -30,10 +30,8 @@ foroSchema.statics.buscarPorActividadId = async function(actividadId) {
     return await this.findOne({ actividad: actividadId }).exec();
 };
 
-module.exports = mongoose.model('Foro', foroSchema);
-
 // Función para consultar comentarios
-module.exports.consultarComentarios = async function (actividadId) {
+foroSchema.statics.consultarComentarios = async function (actividadId) {
     try {
         const foro = await this.findOne({ actividad: actividadId }).populate('comentarios').exec();
         if (!foro) {
@@ -45,3 +43,5 @@ module.exports.consultarComentarios = async function (actividadId) {
         throw error;
     }
 };
+
+module.exports = mongoose.model('Foro', foroSchema);

--- a/models/perfil/usuario.model.js
+++ b/models/perfil/usuario.model.js
@@ -122,6 +122,12 @@ const Usuario = mongoose.model("Usuario", usuarioSchema);
 //   patchPerfil,
 // };
 
+// Función para encontrar un usuario por firebaseUID y devolver firebaseUID y username
+async function findUserByFirebaseUID(firebaseUID) {
+  const usuario = await Usuario.findOne({ firebaseUID: firebaseUID }).select('username firebaseUID').lean();
+  return usuario;
+}
+
 async function patchPerfil(
   firebaseUID,
   imagen,
@@ -158,4 +164,5 @@ module.exports = {
   patchPerfil,
   getImagen,
   deleteUser,
+  findUserByFirebaseUID,
 };

--- a/modules/foro/controllers/foroController.controller.js
+++ b/modules/foro/controllers/foroController.controller.js
@@ -1,36 +1,35 @@
 const Foro = require('../../../models/foro/foro.model');
-const Usuario = require('../../../models/perfil/usuario.model'); 
+const { findUserByFirebaseUID } = require('../../../models/perfil/usuario.model'); 
 
-exports.obtenerForoPorIdDeActividad = async (req, res) => {
+exports.obtenerForoPorIdDeActividad = async (request, response) => {
     try {
         // Obtener el ID de la actividad desde los parámetros de la solicitud
-        const actividadId = req.params.id;
+        const actividadId = request.params.id;
 
-        // Obtener el firebaseUID del usuario desde el token
-        Usuario;
+        // Usar la función consultarComentarios para obtener los comentarios del foro
+        const comentarios = await Foro.consultarComentarios(actividadId);
 
-        // Buscar el foro que corresponde a la actividad y poblar los comentarios
-        const foro = await Foro.findOne({ actividad: actividadId })
-            .populate({
-                path: 'comentarios',
-                populate: {
-                    path: 'firebaseUID',
-                    model: 'Usuario',
-                    select: 'username firebaseUID'
-                }
-            })
-            .exec();
+        // Obtener los usuarios correspondientes a los firebaseUIDs
+        const comentariosConUsuarios = await Promise.all(comentarios.map(async comentario => {
+            const usuario = await findUserByFirebaseUID(comentario.firebaseUID);
+            return {
+                ...comentario.toObject(),
+                username: usuario ? usuario.username : null,
+                firebaseUID: usuario ? usuario.firebaseUID : comentario.firebaseUID
+            };
+        }));
 
-        // Verificar si se encontró el foro
-        if (!foro) {
-            return res.status(404).json({ mensaje: 'No se encontró un foro para esta actividad' });
-        }
+        // Crear la respuesta del foro con los comentarios que incluyen los usuarios
+        const foroConComentarios = {
+            _id: Foro._id, 
+            actividad: actividadId,
+            comentarios: comentariosConUsuarios
+        };
 
-        // Enviar el foro encontrado como respuesta
-        res.status(200).json(foro);
-        console.log(foro);
+        // Enviar el foro encontrado como responsepuesta
+        response.status(200).json(foroConComentarios);
     } catch (error) {
         // Manejar el error
-        res.status(500).json({ mensaje: 'Error al obtener el foro', error: error.message });
+        response.status(500).json({ mensaje: 'Error al obtener el foro', error: error.message });
     }
 };

--- a/modules/foro/controllers/foroController.controller.js
+++ b/modules/foro/controllers/foroController.controller.js
@@ -1,12 +1,25 @@
 const Foro = require('../../../models/foro/foro.model');
+const Usuario = require('../../../models/perfil/usuario.model'); 
 
 exports.obtenerForoPorIdDeActividad = async (req, res) => {
     try {
         // Obtener el ID de la actividad desde los parámetros de la solicitud
         const actividadId = req.params.id;
 
+        // Obtener el firebaseUID del usuario desde el token
+        Usuario;
+
         // Buscar el foro que corresponde a la actividad y poblar los comentarios
-        const foro = await Foro.findOne({ actividad: actividadId }).populate('comentarios').exec();
+        const foro = await Foro.findOne({ actividad: actividadId })
+            .populate({
+                path: 'comentarios',
+                populate: {
+                    path: 'firebaseUID',
+                    model: 'Usuario',
+                    select: 'username firebaseUID'
+                }
+            })
+            .exec();
 
         // Verificar si se encontró el foro
         if (!foro) {
@@ -15,9 +28,9 @@ exports.obtenerForoPorIdDeActividad = async (req, res) => {
 
         // Enviar el foro encontrado como respuesta
         res.status(200).json(foro);
+        console.log(foro);
     } catch (error) {
         // Manejar el error
         res.status(500).json({ mensaje: 'Error al obtener el foro', error: error.message });
     }
 };
-

--- a/modules/foro/controllers/registrarComentario.controller.js
+++ b/modules/foro/controllers/registrarComentario.controller.js
@@ -1,14 +1,15 @@
 const Comentario = require('../../../models/foro/comentario.model');
 const Foro = require('../../../models/foro/foro.model');
 
-exports.registrarComentario = async (req, res) => {
+exports.registrarComentario = async (request, response) => {
     try {
-        const {username, contenido, respuestaDe} = req.body;
-        const foroId = req.params.id;
+        const { contenido, respuestaDe } = request.body;
+        const foroId = request.params.id;
+        const firebaseUID = request.userUID.uid; // Obtener el firebaseUID del request
         
         // Crear el comentario
         const nuevoComentario = new Comentario({
-            username,
+            firebaseUID,
             contenido,
             respuestaDe: respuestaDe || null // Si es una respuesta a otro comentario
         });
@@ -19,21 +20,20 @@ exports.registrarComentario = async (req, res) => {
         // Añadir el comentario al foro
         const foro = await Foro.findById(foroId);
         if (!foro) {
-            return res.status(404).json({ message: 'Foro no encontrado' });
+            return response.status(404).json({ message: 'Foro no encontrado' });
         }
 
         foro.comentarios.push(comentarioGuardado._id.toString());
         await foro.save();
 
-        return res.status(201).json({
+        return response.status(201).json({
             message: 'Comentario registrado con éxito',
             comentario: comentarioGuardado
         });
     } catch (error) {
-        return res.status(500).json({
+        return response.status(500).json({
             message: 'Error al registrar el comentario',
             error: error.message
         });
     }
 };
-


### PR DESCRIPTION
Modificar la creacición de un comentario para que guarde el firebaseUID que es único como identificador del usuario que realiza en comentario.
Modificar la consulta para obtener al username a partir del firebaseUID en su documento correspondiente en la colección Usuario.